### PR TITLE
Fix to MethodError calling Union method

### DIFF
--- a/Chapter06/unions.jl
+++ b/Chapter06/unions.jl
@@ -38,7 +38,7 @@ VecOrPoint = Union{Vector2D, Point}
 isa(p, VecOrPoint) #> true
 isa(v, VecOrPoint) #> true
 
-+(u::VecOrPoint, v:: VecOrPoint) = VecOrPoint(u.x + v.x, u.y + v.y)
++(u::VecOrPoint, v:: VecOrPoint) = Point(u.x + v.x, u.y + v.y) #> or typeof(u)(u.x + v.x, u.y + v.y) to vary the return type
 +(p, v) #> Point(5.0,7.0)
 
 *(u::VecOrPoint, v:: VecOrPoint) = u.x * v.x + u.y * v.y


### PR DESCRIPTION
The current version of the Union example throws a method error trying to call the Union version of the addition method:

```
julia> +(p, v) #> Point(5.0,7.0)
ERROR: MethodError: no method matching Union{Point, Vector2D}(::Float64, ::Float64)
Stacktrace:
 [1] +(::Point, ::Vector2D) at ./REPL[21]:1
 [2] top-level scope at none:0
```

This PR includes a change to return a concrete instance of the Point type instead of trying to construct the abstract union type